### PR TITLE
Bfloat fix

### DIFF
--- a/clt/activation_generation/generator.py
+++ b/clt/activation_generation/generator.py
@@ -41,7 +41,7 @@ from contextlib import contextmanager
 from collections import defaultdict
 import psutil
 
-from clt.training.utils import to_bfloat16
+from clt.training.utils import torch_bfloat16_to_numpy_uint16
 
 try:
     import GPUtil
@@ -768,9 +768,8 @@ class ActivationGenerator:
                                 with self._conditional_measure(f"chunk_{chunk_idx}_layer_{lid}_convert_numpy"):
                                     # Handle bfloat16 conversion
                                     if h5py_dtype_str == "uint16":
-                                        inp_np = to_bfloat16(inp_perm.to(torch.float32).numpy())
-                                        tgt_np = to_bfloat16(tgt_perm.to(torch.float32).numpy())
-
+                                        inp_np = torch_bfloat16_to_numpy_uint16(inp_perm)
+                                        tgt_np = torch_bfloat16_to_numpy_uint16(tgt_perm)
                                     else:
                                         inp_np = inp_perm.to(self.torch_dtype).numpy()
                                         tgt_np = tgt_perm.to(self.torch_dtype).numpy()

--- a/clt/training/utils.py
+++ b/clt/training/utils.py
@@ -1,6 +1,7 @@
 import datetime
 
 import numpy as np
+import torch
 
 
 # Helper function to format elapsed time
@@ -15,5 +16,5 @@ def _format_elapsed_time(seconds: float) -> str:
         return f"{minutes:02d}:{seconds:02d}"
 
 
-def to_bfloat16(x: np.ndarray) -> np.ndarray:
-    return np.frombuffer(np.array(x, dtype=np.float32).tobytes()[::2], dtype=np.uint16)
+def torch_bfloat16_to_numpy_uint16(x: torch.Tensor) -> np.ndarray:
+    return np.frombuffer(x.float().numpy().tobytes(), dtype=np.uint16)[1::2].reshape(x.shape)

--- a/clt/training/utils.py
+++ b/clt/training/utils.py
@@ -1,5 +1,7 @@
 import datetime
 
+import numpy as np
+
 
 # Helper function to format elapsed time
 def _format_elapsed_time(seconds: float) -> str:
@@ -11,3 +13,7 @@ def _format_elapsed_time(seconds: float) -> str:
         return f"{td.days * 24 + hours:02d}:{minutes:02d}:{seconds:02d}"
     else:
         return f"{minutes:02d}:{seconds:02d}"
+
+
+def to_bfloat16(x: np.ndarray) -> np.ndarray:
+    return np.frombuffer(np.array(x, dtype=np.float32).tobytes()[::2], dtype=np.uint16)


### PR DESCRIPTION
When running `scripts/generate_activations.py`, this [line](https://github.com/curt-tigges/crosslayer-coding/blob/8696f037a77c9eeac2070250a20ef68aaf554f53/clt/activation_generation/generator.py#L767-L768) throws an error `TypeError: Got unsupported ScalarType BFloat16`, as numpy doesn't support bfloat16. 

This introduces quick fix to manually convert torch tensor to numpy uint16.

