### PR TITLE
Remove jumprelu_threshold validation rule

### DIFF
--- a/clt/config/clt_config.py
+++ b/clt/config/clt_config.py
@@ -40,7 +40,6 @@ class CLTConfig:
         assert self.num_features > 0, "Number of features must be positive"
         assert self.num_layers > 0, "Number of layers must be positive"
         assert self.d_model > 0, "Model dimension must be positive"
-        assert self.jumprelu_threshold > 0, "JumpReLU threshold must be positive"
         valid_norm_methods = ["auto", "estimated_mean_std", "none"]
         assert (
             self.normalization_method in valid_norm_methods

--- a/clt/models/theta.py
+++ b/clt/models/theta.py
@@ -48,6 +48,10 @@ class ThetaManager(nn.Module):
             self.rank = dist.get_rank(process_group)
 
         if self.config.activation_fn == "jumprelu":
+            if self.config.jumprelu_threshold == 0:
+                logger.warning(
+                    f"Rank {self.rank}: jumprelu_threshold is 0, expecting to load log_threshold from checkpoint."
+                )
             initial_threshold_val = torch.ones(
                 config.num_layers, config.num_features, device=self.device, dtype=self.dtype
             ) * torch.log(torch.tensor(config.jumprelu_threshold, device=self.device, dtype=self.dtype))


### PR DESCRIPTION
When loading model converted from BatchTopK to JumpRelu, this error happens: `AssertionError: JumpReLU threshold must be positive`.

During conversion to jumprelu, [jumprelu_threshold is set to 0](https://github.com/curt-tigges/crosslayer-coding/blob/c8aa9c1c6e55f88dbbc55a7a93d64375a6173af9/clt/models/theta.py#L582) which contradicts with [config validation rule](https://github.com/curt-tigges/crosslayer-coding/blob/c8aa9c1c6e55f88dbbc55a7a93d64375a6173af9/clt/config/clt_config.py#L43).

I removed the validation as we expect to load log_threshold from checkpoint now.