### PR TITLE
Change command line arguments from snake_case to kebab-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,15 @@ For training with locally stored activations (`--activation-source local_manifes
 **Example Command:**
 
 ```bash
-python scripts/generate_activations.py \\
-    --model-name gpt2 \\
-    --dataset-path monology/pile-uncopyrighted \\
-    --mlp-input-template "transformer.h.{}.mlp.c_fc" \\
-    --mlp-output-template "transformer.h.{}.mlp.c_proj" \\
-    --activation-dir ./tutorial_activations \\
-    --target-total-tokens 2000000 \\
-    --chunk-token-threshold 1000000 \\
-    --activation_dtype bfloat16 \\
+python scripts/generate_activations.py \
+    --model-name gpt2 \
+    --dataset-path monology/pile-uncopyrighted \
+    --mlp-input-template "transformer.h.{}.mlp.c_fc" \
+    --mlp-output-template "transformer.h.{}.mlp.c_proj" \
+    --activation-dir ./tutorial_activations \
+    --target-total-tokens 2000000 \
+    --chunk-token-threshold 1000000 \
+    --activation_dtype bfloat16 \
     --compute-norm-stats
 ```
 
@@ -94,24 +94,25 @@ Key configuration parameters are mapped to config classes via script arguments:
 This mode requires activations generated beforehand (see previous section).
 
 ```bash
-python scripts/train_clt.py \\
-    --activation-source local_manifest \\
-    --activation-path ./tutorial_activations/gpt2/pile-uncopyrighted_train \\
-    --output-dir ./clt_output_local \\
-    --model-name gpt2 \\
-    --num-features 3072 \\
-    --activation-fn jumprelu \\
+python scripts/train_clt.py \
+    --activation-source local_manifest \
+    --activation-path ./tutorial_activations/gpt2/pile-uncopyrighted_train \
+    --output-dir ./clt_output_local \
+    --model-name gpt2 \
+    --num-features 3072 \
+    --activation-fn jumprelu \
     --learning-rate 3e-4 \\
-    --training-steps 50000 \\
-    --train-batch-size-tokens 4096 \\
-    --sparsity-lambda 1e-3 \\
-    --normalization-method auto \\
-    --log-interval 100 \\
-    --eval-interval 1000 \\
-    --checkpoint-interval 1000 \\
-    --enable-wandb --wandb-project clt-training-local
+    --training-steps 50000 \
+    --train-batch-size-tokens 4096 \
+    --sparsity-lambda 1e-3 \
+    --normalization-method auto \
+    --log-interval 100 \
+    --eval-interval 1000 \
+    --checkpoint-interval 1000 \
+    --enable-wandb --wandb-project clt_training_local
     # Add other arguments as needed
 ```
+
 
 **Example: Training from a Remote Activation Server (`remote`)**
 
@@ -134,7 +135,7 @@ python scripts/train_clt.py \\
     --log-interval 100 \\
     --eval-interval 1000 \\
     --checkpoint-interval 1000 \\
-    --enable-wandb --wandb-project clt-training-remote
+    --enable-wandb --wandb-project clt_training_remote
     # Add other arguments as needed
 ```
 
@@ -153,11 +154,10 @@ Use `torchrun` (or `torch.distributed.launch`) to start the training script on m
 
 **Example: Training on 4 GPUs (Single Node)**
 
-Assume you have 4 GPUs available on the current machine. Use `torchrun --nproc_per_node=4` to launch the script. The command-line arguments passed to `train_clt.py` are the same as for single-GPU training.
 
 ```bash
 # Example using local manifest data on 4 GPUs
-torchrun --nproc_per_node=4 scripts/train_clt.py \
+torchrun --nproc-per-node=4 scripts/train_clt.py \
     --activation-source local_manifest \
     --activation-path ./tutorial_activations/gpt2/pile-uncopyrighted_train \
     --output-dir ./clt_output_local_4gpu \
@@ -172,13 +172,13 @@ torchrun --nproc_per_node=4 scripts/train_clt.py \
     --log-interval 100 \
     --eval-interval 1000 \
     --checkpoint-interval 1000 \
-    --enable-wandb --wandb-project clt-training-local-4gpu
+    --enable-wandb --wandb-project clt_training_local_4gpu
     # Add other arguments as needed
 ```
 
 **Multi-Node Training:**
 Scaling to multiple nodes requires:
-1.  Setting up the `torchrun` command appropriately with `--nnodes`, `--node_rank`, `--rdzv_id`, `--rdzv_backend`, and `--rdzv_endpoint`. See the [torchrun documentation](https://pytorch.org/docs/stable/elastic/run.html).
+1.  Setting up the `torchrun` command appropriately with `--nnodes`, `--node-rank`, `--rdzv-id`, `--rdzv-backend`, and `--rdzv-endpoint`. See the [torchrun documentation](https://pytorch.org/docs/stable/elastic/run.html).
 2.  Ensuring data accessibility for all nodes:
     *   **Local Manifest:** Requires a shared filesystem mounted at the *same path* on all nodes.
     *   **Remote Server:** The activation server URL must be reachable from all training nodes. The central server might become a bottleneck; make sure it is fast and has a good connection.
@@ -186,21 +186,21 @@ Scaling to multiple nodes requires:
 
 ### Resuming Training from a Checkpoint
 
-To resume training from a previously saved checkpoint, use the `--resume_from_checkpoint_dir` argument with the `scripts/train_clt.py` command. The script will attempt to load the latest checkpoint (`clt_checkpoint_latest.safetensors` and `trainer_state_latest.pt` for non-distributed, or the `latest/` directory for distributed runs) from the specified directory.
+To resume training from a previously saved checkpoint, use the `--resume-from-checkpoint-dir` argument with the `scripts/train_clt.py` command. The script will attempt to load the latest checkpoint (`clt_checkpoint_latest.safetensors` and `trainer_state_latest.pt` for non-distributed, or the `latest/` directory for distributed runs) from the specified directory.
 
 **Key aspects of resuming:**
 
-1.  **Configuration Loading**: When resuming, the script will look for `cli_args.json` in the `--resume_from_checkpoint_dir`. If found, it loads the command-line arguments from the original run. You can override certain parameters by providing them in the current command (e.g., extend `--training-steps`). If `cli_args.json` is not found, a warning is issued, and the current command-line arguments are used (you must ensure all necessary configurations are provided).
-2.  **Output Directory**: The `output_dir` for the resumed run will be the same as the `--resume_from_checkpoint_dir`.
+1.  **Configuration Loading**: When resuming, the script will look for `cli_args.json` in the `--resume-from-checkpoint-dir`. If found, it loads the command-line arguments from the original run. You can override certain parameters by providing them in the current command (e.g., extend `--training-steps`). If `cli_args.json` is not found, a warning is issued, and the current command-line arguments are used (you must ensure all necessary configurations are provided).
+2.  **Output Directory**: The `output_dir` for the resumed run will be the same as the `--resume-from-checkpoint-dir`.
 3.  **WandB Resumption**: If the original run used Weights & Biases (WandB) and the WandB run ID was saved in the checkpoint (`trainer_state_latest.pt`), the resumed training will attempt to continue logging to the *same* WandB run. Do **not** specify `--wandb-run-name` when resuming if you want to continue the original run; the ID from the checkpoint will be used.
-4.  **Specific Step**: You can resume from a specific checkpoint step (instead of `latest`) by also providing the `--resume_step <step_number>` argument. For non-distributed runs, it will look for `clt_checkpoint_<step_number>.safetensors`. For distributed runs, it will look for the `step_<step_number>/` directory.
+4.  **Specific Step**: You can resume from a specific checkpoint step (instead of `latest`) by also providing the `--resume-step <step_number>` argument. For non-distributed runs, it will look for `clt_checkpoint_<step_number>.safetensors`. For distributed runs, it will look for the `step_<step_number>/` directory.
 5.  **State Restoration**: The trainer restores the model weights, optimizer state, scheduler state, gradient scaler state, and the state of the data sampler (including RNG states for PyTorch, NumPy, and Python's `random` module). 
 
 **Example: Resuming a Non-Distributed Run**
 
 ```bash
 python scripts/train_clt.py \
-    --resume_from_checkpoint_dir ./clt_output_local \
+    --resume-from-checkpoint-dir ./clt_output_local \
     # Optional: --resume_step 10000 # To resume from step 10000 specifically
     # Optional: --training-steps 60000 # To extend training beyond original steps (this number should be total including past steps)
     # Ensure other necessary args are present if cli_args.json is missing or you need to override them.
@@ -211,8 +211,8 @@ python scripts/train_clt.py \
 **Example: Resuming a Distributed Run (e.g., 4 GPUs)**
 
 ```bash
-torchrun --nproc_per_node=4 scripts/train_clt.py \
-    --resume_from_checkpoint_dir ./clt_output_local_4gpu \
+torchrun --nproc-per-node=4 scripts/train_clt.py \
+    --resume-from-checkpoint-dir ./clt_output_local_4gpu \
     # Optional: --resume_step 10000
     # Optional: --training-steps 60000
     --enable-wandb
@@ -229,11 +229,11 @@ Using half-precision (like float16 or bfloat16) can significantly reduce memory 
 **1. For Activation Generation:**
 
 When generating activation datasets with `scripts/generate_activations.py`:
-*   Use the `--activation_dtype` argument to specify the precision for *storing* the activations. Options include `float16`, `bfloat16`, or `float32` (default).
+*   Use the `--activation-dtype` argument to specify the precision for *storing* the activations. Options include `float16`, `bfloat16`, or `float32` (default).
     ```bash
     python scripts/generate_activations.py \
         # ... other arguments ... \
-        --activation_dtype float16 # or bfloat16
+        --activation-dtype float16 # or bfloat16
     ```
 *   **Benefit**: Storing activations in `float16` or `bfloat16` reduces disk space by roughly half compared to `float32`.
 
@@ -246,12 +246,12 @@ When training a CLT model with `scripts/train_clt.py`:
     *   `fp32`: Standard float32 training (default).
     ```bash
     # Example for bf16 training
-    torchrun --nproc_per_node=<num_gpus> scripts/train_clt.py \
+    torchrun --nproc-per-node=<num_gpus> scripts/train_clt.py \
         # ... other arguments ... \
         --precision bf16
 
     # Example for fp16 training
-    torchrun --nproc_per_node=<num_gpus> scripts/train_clt.py \
+    torchrun --nproc-per-node=<num_gpus> scripts/train_clt.py \
         # ... other arguments ... \
         --precision fp16
     ```
@@ -264,7 +264,7 @@ We strongly recommend using `batchtopk` (or `topk`) as the activation function (
 
 After training, these implicit thresholds can be converted to explicit, fixed per-feature thresholds for a `jumprelu` activation function. This conversion is performed by the `scripts/convert_batchtopk_to_jumprelu.py` script. The process involves:
 1. **Initial Theta Estimation**: The script first estimates initial per-feature thresholds by analyzing the minimum selected pre-activation values of features from the original model over a dataset.
-2. **Layer-wise L0 Calibration (Crucial Step)**: Since the initial conversion might not perfectly replicate the layer-wise L0 sparsity of the original model, an optional but highly recommended calibration step is performed if `--l0_layerwise_calibrate` is set. This step:
+2. **Layer-wise L0 Calibration (Crucial Step)**: Since the initial conversion might not perfectly replicate the layer-wise L0 sparsity of the original model, an optional but highly recommended calibration step is performed if `--l0-layerwise-calibrate` is set. This step:
     - Determines the target L0 norm (average number of active features per token) for each layer from the original BatchTopK/TopK model.
     - Adjusts the per-feature JumpReLU thresholds in the converted model, layer by layer, to match these target L0s. This is done by finding a scaling factor for each layer's thresholds via binary search.
 This calibration helps ensure the converted JumpReLU model closely mimics the sparsity characteristics of the original, better preserving its performance.
@@ -277,25 +277,25 @@ This calibration helps ensure the converted JumpReLU model closely mimics the sp
 *   `--output-config-path`: Path to save the converted JumpReLU model's config.
 *   `--num-batches-for-theta-estimation`: Number of batches to use for initial theta estimation.
 *   `--default-theta_value`: Default threshold for features that never activated during estimation.
-*   `--l0_layerwise_calibrate`: Flag to enable the layer-wise L0 calibration (recommended).
-*   `--l0_calibration_batches`, `--l0_calibration_batch_size_tokens`: Parameters for data used during L0 calibration.
-*   `--l0_target_model_config_path`, `--l0_target_model_checkpoint_path`: Paths to the original model if different from the main input, for deriving L0 targets.
-*   `--l0_calibration_tolerance`, `--l0_calibration_search_min_scale`, `--l0_calibration_search_max_scale`, `--l0_calibration_max_iters`: Control parameters for the layer-wise calibration search.
+*   `--l0-layerwise_calibrate`: Flag to enable the layer-wise L0 calibration (recommended).
+*   `--l0-calibration-batches`, `--l0-calibration-batch-size-tokens`: Parameters for data used during L0 calibration.
+*   `--l0-target-model-config-path`, `--l0-target-model-checkpoint-path`: Paths to the original model if different from the main input, for deriving L0 targets.
+*   `--l0-calibration-tolerance`, `--l0-calibration-search-min-scale`, `--l0-calibration-search-max-scale`, `--l0-calibration-max-iters`: Control parameters for the layer-wise calibration search.
 
 Run `python scripts/convert_batchtopk_to_jumprelu.py --help` for details.
 
 **Example Command:**
 ```bash
-python scripts/convert_batchtopk_to_jumprelu.py \\
-  --batchtopk_checkpoint_path /path/to/your/batchtopk_model_checkpoint_dir \\
-  --config_path /path/to/your/batchtopk_model_config.json \\
-  --activation_data_path /path/to/your/activation_dataset_for_estimation_and_calibration \\
-  --output_model_path /path/to/converted_jumprelu_model.pt \\
-  --output_config_path /path/to/converted_jumprelu_config.json \\
-  --num_batches_for_theta_estimation 100 \\
-  --l0_layerwise_calibrate \\
-  --l0_calibration_batches 10 \\
-  --l0_calibration_tolerance 0.5 # Adjust as needed
+python scripts/convert_batchtopk_to_jumprelu.py \
+  --batchtopk-checkpoint-path /path/to/your/batchtopk_model_checkpoint_dir \
+  --config-path /path/to/your/batchtopk_model_config.json \
+  --activation-data-path /path/to/your/activation_dataset_for_estimation_and_calibration \
+  --output-model-path /path/to/converted_jumprelu_model.pt \
+  --output-config-path /path/to/converted_jumprelu_config.json \
+  --num-batches-for-theta-estimation 100 \
+  --l0-layerwise-calibrate \
+  --l0-calibration-batches 10 \
+  --l0-calibration-tolerance 0.5 # Adjust as needed
 ```
 
 ## Training with a Remote Activation Server
@@ -317,9 +317,9 @@ For detailed instructions on setting up and running the `clt_server`, please ref
 The script `scripts/scramble_dataset.py` can be used to take an existing locally stored dataset (generated by `generate_activations.py`) and create a new version where all activation rows are globally shuffled across all chunks. This is useful if you want to train using random samples from the entire dataset without relying on the `random_chunk` sampling strategy during training.
 
 ```bash
-python scripts/scramble_dataset.py \\
-    --input-dir /path/to/original/dataset \\
-    --output-dir /path/to/scrambled/dataset \\
+python scripts/scramble_dataset.py \
+    --input-dir /path/to/original/dataset \
+    --output-dir /path/to/scrambled/dataset \
     --seed 42 # Optional seed for reproducibility
 ```
 

--- a/scripts/compress_activation_dataset.py
+++ b/scripts/compress_activation_dataset.py
@@ -36,31 +36,31 @@ def parse_arguments():
     """Parse command-line arguments for dataset compression."""
     parser = argparse.ArgumentParser(description="Compress an HDF5 activation dataset to Zarr format.")
     parser.add_argument(
-        "--input_dir",
+        "--input-dir",
         type=str,
         required=True,
         help="Path to the input HDF5 activation dataset directory (e.g., ./activations/model/dataset_split).",
     )
     parser.add_argument(
-        "--output_dir",
+        "--output-dir",
         type=str,
         required=True,
         help="Path to the output Zarr activation dataset directory.",
     )
     parser.add_argument(
-        "--zarr_chunk_size",
+        "--zarr-chunk-size",
         type=int,
         default=1000,  # Default Zarr chunking along the token dimension
         help="Chunk size for the first dimension (tokens) in the output Zarr arrays.",
     )
     parser.add_argument(
-        "--compression_level",
+        "--compression-level",
         type=int,
         default=5,  # Blosc default is 5
         help="Blosc compression level (0-9). 0 means no compression, 9 is max.",
     )
     parser.add_argument(
-        "--compression_shuffle",
+        "--compression-shuffle",
         type=int,
         default=1,  # Default to Blosc.SHUFFLE
         choices=[0, 1, 2],  # Blosc.NOSHUFFLE, Blosc.SHUFFLE, Blosc.BITSHUFFLE

--- a/scripts/convert_batchtopk_to_jumprelu.py
+++ b/scripts/convert_batchtopk_to_jumprelu.py
@@ -772,57 +772,57 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--batchtopk_checkpoint_path",
+        "--batchtopk-checkpoint-path",
         type=str,
         required=True,
         help="Path to the saved BatchTopK model checkpoint (.pt file or sharded directory).",
     )
     parser.add_argument(
-        "--config_path",
+        "--config-path",
         type=str,
         required=True,
         help="Path to the JSON config file corresponding to the BatchTopK model.",
     )
     parser.add_argument(
-        "--activation_data_path",
+        "--activation-data-path",
         type=str,
         required=True,
         help="Path to the activation data manifest directory (for LocalActivationStore).",
     )
     parser.add_argument(
-        "--output_model_path",
+        "--output-model-path",
         type=str,
         required=True,
         help="Path to save the converted JumpReLU model's state_dict (.pt).",
     )
     parser.add_argument(
-        "--output_config_path",
+        "--output-config-path",
         type=str,
         required=True,
         help="Path to save the converted JumpReLU model's config (.json).",
     )
 
     parser.add_argument(
-        "--num_batches_for_theta_estimation",
+        "--num-batches-for-theta-estimation",
         type=int,
         default=100,
         help="Number of batches to use for theta estimation.",
     )
     parser.add_argument(
-        "--estimation_batch_size_tokens",
+        "--estimation-batch-size-tokens",
         type=int,
         default=1024,
         help="Number of tokens per batch for theta estimation.",
     )
     parser.add_argument(
-        "--default_theta_value", type=float, default=1e6, help="Default theta value for features that never activated."
+        "--default-theta-value", type=float, default=1e6, help="Default theta value for features that never activated."
     )
 
     parser.add_argument(
         "--device", type=str, default=None, help="Device to use (e.g., 'cpu', 'cuda', 'cuda:0'). Auto-detects if None."
     )
     parser.add_argument(
-        "--activation_dtype",
+        "--activation-dtype",
         type=str,
         default="float32",
         help="Data type for loading activations (e.g., 'float16', 'bfloat16', 'float32').",
@@ -831,19 +831,19 @@ if __name__ == "__main__":
         "--seed", type=int, default=42, help="Random seed for activation store sampling (if applicable)."
     )
     parser.add_argument(
-        "--num_tokens_for_l0_check_script",
+        "--num-tokens-for-l0-check-script",
         type=int,
         default=1024,
         help="Number of random tokens to sample from the collected data for the empirical L0 check in this script.",
     )
     parser.add_argument(
-        "--num_batches_for_l0_check",
+        "--num-batches-for-l0-check",
         type=int,
         default=1,
         help="Number of batches to fetch from activation store for the empirical L0 check.",
     )
     parser.add_argument(
-        "--l0_check_batch_size_tokens",
+        "--l0-check-batch-size-tokens",
         type=int,
         default=None,  # Default to None, will use estimation_batch_size_tokens if not set
         help="Number of tokens per batch for fetching data for the L0 check. Defaults to estimation_batch_size_tokens if not specified.",
@@ -851,54 +851,54 @@ if __name__ == "__main__":
 
     # Args for Layer-wise L0 Calibration
     parser.add_argument(
-        "--l0_layerwise_calibrate",
+        "--l0-layerwise-calibrate",
         action="store_true",
         help="If set, perform an additional calibration step to match layer-wise L0s from the original model.",
     )
     parser.add_argument(
-        "--l0_calibration_batches",
+        "--l0-calibration-batches",
         type=int,
         default=1,
         help="Number of batches from activation_data_path to use for L0 calibration step.",
     )
     parser.add_argument(
-        "--l0_calibration_batch_size_tokens",
+        "--l0-calibration-batch-size-tokens",
         type=int,
         default=None,
         help="Batch size in tokens for L0 calibration. Defaults to l0_check_batch_size_tokens or estimation_batch_size_tokens.",
     )
     parser.add_argument(
-        "--l0_target_model_config_path",
+        "--l0-target-model-config-path",
         type=str,
         default=None,
         help="Path to the original model's config JSON for L0 target calculation. Defaults to --config_path.",
     )
     parser.add_argument(
-        "--l0_target_model_checkpoint_path",
+        "--l0-target-model-checkpoint-path",
         type=str,
         default=None,
         help="Path to the original model's checkpoint for L0 target calculation. Defaults to --batchtopk_checkpoint_path.",
     )
     parser.add_argument(
-        "--l0_calibration_tolerance",
+        "--l0-calibration-tolerance",
         type=float,
         default=0.5,
         help="Tolerance (in number of active features) for matching target L0 during layer-wise calibration.",
     )
     parser.add_argument(
-        "--l0_calibration_search_min_scale",
+        "--l0-calibration-search-min-scale",
         type=float,
         default=0.1,
         help="Minimum scale factor for layer-wise L0 calibration search.",
     )
     parser.add_argument(
-        "--l0_calibration_search_max_scale",
+        "--l0-calibration-search-max-scale",
         type=float,
         default=10.0,
         help="Maximum scale factor for layer-wise L0 calibration search.",
     )
     parser.add_argument(
-        "--l0_calibration_max_iters",
+        "--l0-calibration-max-iters",
         type=int,
         default=15,
         help="Maximum iterations for binary search per layer during L0 calibration.",
@@ -911,12 +911,12 @@ if __name__ == "__main__":
 
 # Example Usage:
 # python scripts/convert_batchtopk_to_jumprelu.py \\
-#   --batchtopk_checkpoint_path clt_training_logs/clt_pythia_batchtopk_train_XYZ/final \\
-#   --config_path clt_training_logs/clt_pythia_batchtopk_train_XYZ/cfg.json \\
-#   --activation_data_path ./tutorial_activations_local_1M_pythia/EleutherAI/pythia-70m/monology/pile-uncopyrighted_train \\
-#   --output_model_path clt_training_logs/clt_pythia_batchtopk_train_XYZ/final_jumprelu_sf1.5/clt_model_jumprelu.pt \\
-#   --output_config_path clt_training_logs/clt_pythia_batchtopk_train_XYZ/final_jumprelu_sf1.5/cfg_jumprelu.json \\
-#   --num_batches_for_theta_estimation 50 \\
+#   --batchtopk-checkpoint-path clt_training_logs/clt_pythia_batchtopk_train_XYZ/final \\
+#   --config-path clt_training_logs/clt_pythia_batchtopk_train_XYZ/cfg.json \\
+#   --activation-data-path ./tutorial_activations_local_1M_pythia/EleutherAI/pythia-70m/monology/pile-uncopyrighted_train \\
+#   --output-model-path clt_training_logs/clt_pythia_batchtopk_train_XYZ/final_jumprelu_sf1.5/clt_model_jumprelu.pt \\
+#   --output-config-path clt_training_logs/clt_pythia_batchtopk_train_XYZ/final_jumprelu_sf1.5/cfg_jumprelu.json \\
+#   --num-batches-for-theta-estimation 50 \\
 #   --device cuda
-#   --l0_layerwise_calibrate \
-#   --l0_calibration_tolerance 0.2
+#   --l0-layerwise-calibrate \
+#   --l0-calibration-tolerance 0.2

--- a/scripts/generate_activations.py
+++ b/scripts/generate_activations.py
@@ -20,31 +20,31 @@ def parse_arguments():
 
     # Arguments map directly to ActivationConfig fields
     # --- Model Source ---
-    parser.add_argument("--model-name", type=str, required=True, help="Model name or path.")
+    parser.add_argument("--model_name", type=str, required=True, help="Model name or path.")
     parser.add_argument(
-        "--mlp-input-template",
+        "--mlp_input_template",
         type=str,
         required=True,
         help="NNsight path template for MLP inputs.",
     )
     parser.add_argument(
-        "--mlp-output-template",
+        "--mlp_output_template",
         type=str,
         required=True,
         help="NNsight path template for MLP outputs.",
     )
     parser.add_argument(
-        "--model-dtype",
+        "--model_dtype",
         type=str,
         default=None,
         help="Optional model dtype (e.g., 'float16').",
     )
 
     # --- Dataset Source ---
-    parser.add_argument("--dataset-path", type=str, required=True, help="Dataset name or path.")
-    parser.add_argument("--dataset-split", type=str, default="train", help="Dataset split.")
+    parser.add_argument("--dataset_path", type=str, required=True, help="Dataset name or path.")
+    parser.add_argument("--dataset_split", type=str, default="train", help="Dataset split.")
     parser.add_argument(
-        "--dataset-text-column",
+        "--dataset_text_column",
         type=str,
         default="text",
         help="Dataset text column name.",
@@ -52,20 +52,20 @@ def parse_arguments():
 
     # --- Generation Parameters ---
     parser.add_argument(
-        "--context-size",
+        "--context_size",
         type=int,
         default=128,
         help="Context size for tokenization/inference.",
     )
-    parser.add_argument("--inference-batch-size", type=int, default=512, help="Inference batch size.")
+    parser.add_argument("--inference_batch_size", type=int, default=512, help="Inference batch size.")
     parser.add_argument(
-        "--exclude-special-tokens",
+        "--exclude_special_tokens",
         action=argparse.BooleanOptionalAction,
         default=True,
         help="Exclude special tokens.",
     )
     parser.add_argument(
-        "--prepend-bos",
+        "--prepend_bos",
         action=argparse.BooleanOptionalAction,
         default=False,
         help="Prepend BOS token.",
@@ -79,7 +79,7 @@ def parse_arguments():
         help="Use HF dataset streaming.",
     )
     parser.add_argument(
-        "--trust-remote-code",
+        "--trust_remote_code",
         action=argparse.BooleanOptionalAction,
         default=False,
         help="Trust remote code for dataset.",
@@ -88,7 +88,7 @@ def parse_arguments():
 
     # --- Generation Output Control ---
     parser.add_argument(
-        "--target-total-tokens",
+        "--target_total_tokens",
         type=int,
         default=None,
         help="Target number of tokens to generate.",
@@ -97,13 +97,13 @@ def parse_arguments():
 
     # --- Storage Parameters ---
     parser.add_argument(
-        "--activation-dir",
+        "--activation_dir",
         type=str,
         default="./activations",
         help="Base directory to save activations.",
     )
     parser.add_argument(
-        "--output-format",
+        "--output_format",
         type=str,
         default="hdf5",
         choices=["hdf5", "npz"],
@@ -116,19 +116,19 @@ def parse_arguments():
         help="Compression ('lz4', 'gzip', or 'None').",
     )
     parser.add_argument(
-        "--chunk-token-threshold",
+        "--chunk_token_threshold",
         type=int,
         default=1_000_000,
         help="Target tokens per chunk file.",
     )
     parser.add_argument(
-        "--remote-server-url",
+        "--remote_server_url",
         type=str,
         default=None,
         help="Optional URL for the remote activation server (e.g., 'http://host:port').",
     )
     parser.add_argument(
-        "--activation-dtype",
+        "--activation_dtype",
         type=str,
         default="float32",
         help="Data type for storing activations (e.g., 'float32', 'bfloat16').",
@@ -136,25 +136,25 @@ def parse_arguments():
 
     # --- Upload Parameters (for remote storage) ---
     parser.add_argument(
-        "--delete-after-upload",
+        "--delete_after_upload",
         action=argparse.BooleanOptionalAction,
         default=False,
         help="Delete local chunk files after successful remote upload.",
     )
     parser.add_argument(
-        "--upload-max-retries",
+        "--upload_max_retries",
         type=int,
         default=5,
         help="Maximum number of upload retries per chunk file (default: 5).",
     )
     parser.add_argument(
-        "--upload-initial-backoff",
+        "--upload_initial_backoff",
         type=float,
         default=1.0,
         help="Initial backoff delay in seconds for upload retries (default: 1.0).",
     )
     parser.add_argument(
-        "--upload-max-backoff",
+        "--upload_max_backoff",
         type=float,
         default=30.0,
         help="Maximum backoff delay in seconds for upload retries (default: 30.0).",
@@ -162,7 +162,7 @@ def parse_arguments():
 
     # --- Normalization ---
     parser.add_argument(
-        "--compute-norm-stats",
+        "--compute_norm_stats",
         action=argparse.BooleanOptionalAction,
         default=True,
         help="Compute and save normalization stats.",
@@ -176,7 +176,7 @@ def parse_arguments():
         help="Device override for generation ('cuda', 'cpu').",
     )
     parser.add_argument(
-        "--storage-type",
+        "--storage_type",
         type=str,
         default="local",
         choices=["local", "remote"],
@@ -185,7 +185,7 @@ def parse_arguments():
 
     # --- Profiling Argument ---
     parser.add_argument(
-        "--enable-profiling",
+        "--enable_profiling",
         action=argparse.BooleanOptionalAction,
         default=False,
         help="Enable detailed performance profiling during activation generation.",
@@ -193,13 +193,13 @@ def parse_arguments():
 
     # --- NNsight Arguments (Potentially pass as JSON strings) ---
     parser.add_argument(
-        "--nnsight-tracer-kwargs-json",
+        "--nnsight_tracer_kwargs_json",
         type=str,
         default="{}",
         help="JSON string for nnsight model.trace() kwargs.",
     )
     parser.add_argument(
-        "--nnsight-invoker-args-json",
+        "--nnsight_invoker_args_json",
         type=str,
         default="{}",
         help="JSON string for nnsight model.trace() invoker_args.",

--- a/scripts/generate_activations.py
+++ b/scripts/generate_activations.py
@@ -20,31 +20,31 @@ def parse_arguments():
 
     # Arguments map directly to ActivationConfig fields
     # --- Model Source ---
-    parser.add_argument("--model_name", type=str, required=True, help="Model name or path.")
+    parser.add_argument("--model-name", type=str, required=True, help="Model name or path.")
     parser.add_argument(
-        "--mlp_input_template",
+        "--mlp-input-template",
         type=str,
         required=True,
         help="NNsight path template for MLP inputs.",
     )
     parser.add_argument(
-        "--mlp_output_template",
+        "--mlp-output-template",
         type=str,
         required=True,
         help="NNsight path template for MLP outputs.",
     )
     parser.add_argument(
-        "--model_dtype",
+        "--model-dtype",
         type=str,
         default=None,
         help="Optional model dtype (e.g., 'float16').",
     )
 
     # --- Dataset Source ---
-    parser.add_argument("--dataset_path", type=str, required=True, help="Dataset name or path.")
-    parser.add_argument("--dataset_split", type=str, default="train", help="Dataset split.")
+    parser.add_argument("--dataset-path", type=str, required=True, help="Dataset name or path.")
+    parser.add_argument("--dataset-split", type=str, default="train", help="Dataset split.")
     parser.add_argument(
-        "--dataset_text_column",
+        "--dataset-text-column",
         type=str,
         default="text",
         help="Dataset text column name.",
@@ -52,20 +52,20 @@ def parse_arguments():
 
     # --- Generation Parameters ---
     parser.add_argument(
-        "--context_size",
+        "--context-size",
         type=int,
         default=128,
         help="Context size for tokenization/inference.",
     )
-    parser.add_argument("--inference_batch_size", type=int, default=512, help="Inference batch size.")
+    parser.add_argument("--inference-batch-size", type=int, default=512, help="Inference batch size.")
     parser.add_argument(
-        "--exclude_special_tokens",
+        "--exclude-special-tokens",
         action=argparse.BooleanOptionalAction,
         default=True,
         help="Exclude special tokens.",
     )
     parser.add_argument(
-        "--prepend_bos",
+        "--prepend-bos",
         action=argparse.BooleanOptionalAction,
         default=False,
         help="Prepend BOS token.",
@@ -79,7 +79,7 @@ def parse_arguments():
         help="Use HF dataset streaming.",
     )
     parser.add_argument(
-        "--trust_remote_code",
+        "--trust-remote-code",
         action=argparse.BooleanOptionalAction,
         default=False,
         help="Trust remote code for dataset.",
@@ -88,7 +88,7 @@ def parse_arguments():
 
     # --- Generation Output Control ---
     parser.add_argument(
-        "--target_total_tokens",
+        "--target-total-tokens",
         type=int,
         default=None,
         help="Target number of tokens to generate.",
@@ -97,13 +97,13 @@ def parse_arguments():
 
     # --- Storage Parameters ---
     parser.add_argument(
-        "--activation_dir",
+        "--activation-dir",
         type=str,
         default="./activations",
         help="Base directory to save activations.",
     )
     parser.add_argument(
-        "--output_format",
+        "--output-format",
         type=str,
         default="hdf5",
         choices=["hdf5", "npz"],
@@ -116,19 +116,19 @@ def parse_arguments():
         help="Compression ('lz4', 'gzip', or 'None').",
     )
     parser.add_argument(
-        "--chunk_token_threshold",
+        "--chunk-token-threshold",
         type=int,
         default=1_000_000,
         help="Target tokens per chunk file.",
     )
     parser.add_argument(
-        "--remote_server_url",
+        "--remote-server-url",
         type=str,
         default=None,
         help="Optional URL for the remote activation server (e.g., 'http://host:port').",
     )
     parser.add_argument(
-        "--activation_dtype",
+        "--activation-dtype",
         type=str,
         default="float32",
         help="Data type for storing activations (e.g., 'float32', 'bfloat16').",
@@ -136,25 +136,25 @@ def parse_arguments():
 
     # --- Upload Parameters (for remote storage) ---
     parser.add_argument(
-        "--delete_after_upload",
+        "--delete-after-upload",
         action=argparse.BooleanOptionalAction,
         default=False,
         help="Delete local chunk files after successful remote upload.",
     )
     parser.add_argument(
-        "--upload_max_retries",
+        "--upload-max-retries",
         type=int,
         default=5,
         help="Maximum number of upload retries per chunk file (default: 5).",
     )
     parser.add_argument(
-        "--upload_initial_backoff",
+        "--upload-initial-backoff",
         type=float,
         default=1.0,
         help="Initial backoff delay in seconds for upload retries (default: 1.0).",
     )
     parser.add_argument(
-        "--upload_max_backoff",
+        "--upload-max-backoff",
         type=float,
         default=30.0,
         help="Maximum backoff delay in seconds for upload retries (default: 30.0).",
@@ -162,7 +162,7 @@ def parse_arguments():
 
     # --- Normalization ---
     parser.add_argument(
-        "--compute_norm_stats",
+        "--compute-norm-stats",
         action=argparse.BooleanOptionalAction,
         default=True,
         help="Compute and save normalization stats.",
@@ -176,7 +176,7 @@ def parse_arguments():
         help="Device override for generation ('cuda', 'cpu').",
     )
     parser.add_argument(
-        "--storage_type",
+        "--storage-type",
         type=str,
         default="local",
         choices=["local", "remote"],
@@ -185,7 +185,7 @@ def parse_arguments():
 
     # --- Profiling Argument ---
     parser.add_argument(
-        "--enable_profiling",
+        "--enable-profiling",
         action=argparse.BooleanOptionalAction,
         default=False,
         help="Enable detailed performance profiling during activation generation.",
@@ -193,13 +193,13 @@ def parse_arguments():
 
     # --- NNsight Arguments (Potentially pass as JSON strings) ---
     parser.add_argument(
-        "--nnsight_tracer_kwargs_json",
+        "--nnsight-tracer-kwargs-json",
         type=str,
         default="{}",
         help="JSON string for nnsight model.trace() kwargs.",
     )
     parser.add_argument(
-        "--nnsight_invoker_args_json",
+        "--nnsight-invoker-args-json",
         type=str,
         default="{}",
         help="JSON string for nnsight model.trace() invoker_args.",

--- a/scripts/train_clt.py
+++ b/scripts/train_clt.py
@@ -47,8 +47,8 @@ def get_model_dimensions(model_name: str) -> tuple[Optional[int], Optional[int]]
 
     try:
         config = AutoConfig.from_pretrained(model_name)
-        num_layers = getattr(config, "num_hidden_layers", None) or getattr(config, "n_layer", None)
-        d_model = getattr(config, "hidden_size", None) or getattr(config, "n_embd", None)
+        num_layers = getattr(config, "num-hidden-layers", None) or getattr(config, "n-layer", None)
+        d_model = getattr(config, "hidden-size", None) or getattr(config, "n-embd", None)
 
         if num_layers is None or d_model is None:
             logger.warning(
@@ -86,7 +86,7 @@ def parse_args():
         "--output-dir",
         type=str,
         default=f"clt_train_{int(time.time())}",
-        help="Directory to save logs, checkpoints, and final model. If resuming, this might be overridden by --resume_from_checkpoint_dir.",
+        help="Directory to save logs, checkpoints, and final model. If resuming, this might be overridden by --resume-from-checkpoint-dir.",
     )
     core_group.add_argument(
         "--model-name",
@@ -106,16 +106,16 @@ def parse_args():
         help="Enable distributed training (requires torchrun/appropriate launcher).",
     )
     core_group.add_argument(
-        "--resume_from_checkpoint_dir",
+        "--resume-from-checkpoint-dir",
         type=str,
         default=None,
-        help="Path to the output directory of a previous run to resume from. Will attempt to load 'latest' or a specific step if --resume_step is also given.",
+        help="Path to the output directory of a previous run to resume from. Will attempt to load 'latest' or a specific step if --resume-step is also given.",
     )
     core_group.add_argument(
-        "--resume_step",
+        "--resume-step",
         type=int,
         default=None,
-        help="Optional specific step to resume from. Used in conjunction with --resume_from_checkpoint_dir.",
+        help="Optional specific step to resume from. Used in conjunction with --resume-from-checkpoint-dir.",
     )
 
     # --- Local Activation Source Parameters ---


### PR DESCRIPTION
The example currently given in README.md will fail since the argument parsre in scripts/generate_activations.py expects snake_case arguments.

I also update the torchrun example. Since torch 2.0 the convention is to use kebab-case for command line arguments, although snake_case is still supported for backwards compatibility, for a new library we should enforce kebab-case.

I've made similar changes to scripts/convert_batchtopk_to_jumprelu.py and scripts/compress_activation_dataset.py, but haven't checked these very closely. I updated them manually but a long term solution would be to have the formatting conventions enforced by a linter (for example, `ruff check` with some pre-defined rules). We may need exceptions to the rules when interacting with external codebases with different conventions.

It's alright to use snake_case in the python snippet at the bottom of the README since we know that `variable_name = getattr(config, "variable-name", None)`.

I'm unsure if cli_args.json requires changes.